### PR TITLE
Adding Windows Compatibility

### DIFF
--- a/Sources/APIRequest/Request/APIRequest.swift
+++ b/Sources/APIRequest/Request/APIRequest.swift
@@ -18,6 +18,7 @@
 */
 
 import Foundation
+import FoundationNetworking
 
 public class APIRequest: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
     


### PR DESCRIPTION
All the URL modules have moved from Foundation to FoundationNetworking in Swift for Windows, and maybe even for Linux